### PR TITLE
Convert ado-migrate-project/pipelines/custom-transformer-example to GitHub Actions

### DIFF
--- a/.github/workflows/custom-transformer-example.yml
+++ b/.github/workflows/custom-transformer-example.yml
@@ -1,0 +1,26 @@
+name: ado-migrate-project/pipelines/custom-transformer-example
+on:
+  push:
+    branches:
+    - "*"
+env:
+  BUILDCONFIGURATION: Release
+  BuildParameters_RESTOREBUILDPROJECTS: "**/*.csproj"
+jobs:
+  Job_1:
+    name: Agent job 1
+    runs-on:
+      - self-hosted
+      - mechamachine
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v4.1.0
+    - name: Use Node 10.16.3
+      uses: actions/setup-node@v4.0.0
+      with:
+        node-version: 10.16.3
+    - name: Restore
+      run: dotnet restore ${{ env.BuildParameters_RESTOREBUILDPROJECTS }}
+    - name: Build
+      run: dotnet build ${{ env.BuildParameters_RESTOREBUILDPROJECTS }} --configuration ${{ env.BUILDCONFIGURATION }}


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/ericsoderqvist/ado-migrate-project/_build?definitionId=1) :tada:

## Manual steps

Perform the following steps to complete the migration:

### ado-migrate-project/pipelines/custom-transformer-example
- [x] Ensure a runner with the following labels exists: mechamachine